### PR TITLE
Change peer dependency to `babel-plugin-emotion` for emotion `^8.0.2` update

### DIFF
--- a/packages/react-app-rewire-emotion/index.js
+++ b/packages/react-app-rewire-emotion/index.js
@@ -1,7 +1,7 @@
 const { injectBabelPlugin } = require('react-app-rewired');
 
 function rewireEmotion(config, env, emotionBabelOptions = {}) {
-  config = injectBabelPlugin(['emotion/babel', emotionBabelOptions], config);
+  config = injectBabelPlugin(['emotion', emotionBabelOptions], config);
   return config;
 }
 

--- a/packages/react-app-rewire-emotion/package.json
+++ b/packages/react-app-rewire-emotion/package.json
@@ -8,6 +8,6 @@
   "author": "osdevisnot <osdevisnot@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "emotion": "^7.2.2"
+    "emotion": "^8.0.2"
   }
 }

--- a/packages/react-app-rewire-emotion/package.json
+++ b/packages/react-app-rewire-emotion/package.json
@@ -8,6 +8,6 @@
   "author": "osdevisnot <osdevisnot@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "emotion": "^8.0.2"
+    "babel-plugin-emotion": "^8.0.2"
   }
 }


### PR DESCRIPTION
These are the changes I had to make to get emotion 8.0.2 to work with `react-app-rewire-emotion`.