### PR TITLE
Add `createEmotionRewire`

### DIFF
--- a/packages/react-app-rewire-emotion/README.md
+++ b/packages/react-app-rewire-emotion/README.md
@@ -16,12 +16,28 @@ npm install --save-dev react-app-rewire-emotion
 In the `config-overrides.js` you created for `react-app-rewired` add this code:
 
 ```
-const rewireEmotion = require('react-app-rewire-emotion');
+const { rewireEmotion } = require('react-app-rewire-emotion');
 
 /* config-overrides.js */
 module.exports = function override(config, env) {
   return rewireEmotion(config, env, { inline: true });
 }
+```
+
+If you are using `compose` utility provided by `react-app-rewired` to add multiple rewires, use this code:
+```
+const { compose } = require('react-app-rewired');
+const { createEmotionRewire } = require('react-app-rewire-emotion');
+
+/* config-overrides.js */
+module.exports = function override(config, env) {
+  const rewires = compose(
+    createRewireForSomeOtherPlugin(),
+    // ... place more rewires
+    createEmotionRewire({ inline: true }),
+  );
+  return rewires(config, env);
+};
 ```
 
 ## Usage with Storybook

--- a/packages/react-app-rewire-emotion/index.js
+++ b/packages/react-app-rewire-emotion/index.js
@@ -5,4 +5,11 @@ function rewireEmotion(config, env, emotionBabelOptions = {}) {
   return config;
 }
 
-module.exports = rewireEmotion;
+function createEmotionRewire(emotionBabelOptions) {
+  return function (config, env) {
+    return rewireEmotion(config, env, emotionBabelOptions);
+  };
+}
+
+module.exports.rewireEmotion = rewireEmotion;
+module.exports.createEmotionRewire = createEmotionRewire;


### PR DESCRIPTION
`react-app-rewired` offers [compose](https://github.com/timarney/react-app-rewired#2-composeafter-v134) utility which you can use to compose multiple rewires. This PR adds `createEmotionRewire` which makes using `compose` possible without user land code.

This PR results in breaking change, `rewireEmotion` is not a default export from now.