### PR TITLE
Use correct way to declare "v8 or v9" of babel-plugin-emotion as peer dependency

### DIFF
--- a/packages/react-app-rewire-emotion/package.json
+++ b/packages/react-app-rewire-emotion/package.json
@@ -8,6 +8,6 @@
   "author": "osdevisnot <osdevisnot@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "babel-plugin-emotion": "^8 || ^9"
+    "babel-plugin-emotion": "^8.0.0 || ^9.0.0"
   }
 }


### PR DESCRIPTION
the previous `"babel-plugin-emotion": "^8 || ^9"` issues this warning:
```react-app-rewire-emotion@4.0.0" has unmet peer dependency "babel-plugin-emotion@^8 || ^9"```
even though `babel-plugin-emotion^9.2.6` is installed